### PR TITLE
fix(zfs): limit ARC max to 60% of RAM on NAS hosts

### DIFF
--- a/nixos/hosts/away-nas.nix
+++ b/nixos/hosts/away-nas.nix
@@ -42,6 +42,7 @@
 
   # Bootloader.
   # Use the systemd-boot EFI boot loader.
+  boot.kernelParams = [ "zfs.zfs_arc_max=4831838208" ];
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 

--- a/nixos/hosts/home-nas.nix
+++ b/nixos/hosts/home-nas.nix
@@ -31,7 +31,7 @@
   # zpool create -O compression=on -O mountpoint=none -O xattr=sa -O acltype=posixacl -o ashift=12 home-nas mirror /dev/disk/by-id/xxx /dev/disk/by-id/xxx
   # zfs set com.sun:auto-snapshot=true home-nas
   # zfs create -o mountpoint=legacy home-nas/local
-  # boot.kernelParams = [ "zfs.zfs_arc_max=1073741824" ];
+  boot.kernelParams = [ "zfs.zfs_arc_max=9663676416" ];
 
   # Configure a bridge for libvirtd
   networking.bridges.br0.interfaces = [ "enp2s0" ];


### PR DESCRIPTION
ZFS ARC was consuming 80%+ of RAM on home-nas (12.4 GiB of 15.4 GiB), triggering memory alerts.

Both NAS hosts use NixOS with impermanence (tmpfs root), so available RAM matters more than on a typical setup — the OS itself needs working memory from RAM, not just disk-backed pages.

This caps ZFS ARC max at 60% of total RAM on both hosts:

- **home-nas** (16 GiB): `zfs.zfs_arc_max=9663676416` (~9.0 GiB)
- **away-nas** (8 GiB): `zfs.zfs_arc_max=4831838208` (~4.5 GiB)

Set via `boot.kernelParams` so it takes effect at boot. Requires a reboot to apply.