### PR TITLE
feat(mierin): add Docker Hub pull-through cache registry

### DIFF
--- a/nixos/hosts/mierin.nix
+++ b/nixos/hosts/mierin.nix
@@ -17,6 +17,7 @@
       ../includes/mikr.nix
       ../includes/node-exporter.nix
       ../includes/physical.nix
+      ../includes/docker-registry-cache.nix
       ../includes/router.nix
       ../includes/ssh.nix
       ../includes/sudo.nix

--- a/nixos/includes/docker-registry-cache.nix
+++ b/nixos/includes/docker-registry-cache.nix
@@ -1,0 +1,16 @@
+{ config, pkgs, ... }:
+
+{
+  services.dockerRegistry = {
+    enable = true;
+    listenAddress = "10.0.1.1";
+    port = 5001;
+    storagePath = "/opt/local/dockercache/dockerhub";
+    enableDelete = true;
+    extraConfig = {
+      proxy = {
+        remoteurl = "https://registry-1.docker.io";
+      };
+    };
+  };
+}

--- a/nixos/includes/router.nix
+++ b/nixos/includes/router.nix
@@ -43,6 +43,7 @@
         allowedTCPPorts = [
           22 # SSH
           53 # DNSmasq
+          5001 # Docker Registry pull-through cache
           8404 # node-exporter for HAproxy
           9100 # node-exporter
           9153 # node-exporter for DNSmasq


### PR DESCRIPTION
Adds a Docker Registry pull-through cache on Mierin for Docker Hub images.

## Changes
- **`nixos/includes/docker-registry-cache.nix`** — new service config
  - Pull-through proxy for `registry-1.docker.io`
  - Listens on `10.0.1.1:5001` (LAN only)
  - Storage at `/opt/local/dockercache/dockerhub` (persistent via impermanence)
  - `enableDelete = true` for future GC support
- **`nixos/hosts/mierin.nix`** — import the new include
- **`nixos/includes/router.nix`** — open port 5001 on LAN interface

## Why
Resilience against Docker Hub rate limits (100 pulls/6h anonymous). Cached images served from LAN on subsequent pulls.

## Next step
After deploying and verifying, a separate cluster-ops PR will add `machine.registries.mirrors` to Talos config to point nodes at the cache.