### PR TITLE
fix(mierin): add restart policy for docker-registry

### DIFF
--- a/nixos/includes/docker-registry-cache.nix
+++ b/nixos/includes/docker-registry-cache.nix
@@ -13,4 +13,9 @@
       };
     };
   };
+
+  systemd.services.docker-registry.serviceConfig = {
+    Restart = "on-failure";
+    RestartSec = "5s";
+  };
 }


### PR DESCRIPTION
The registry panics on startup if DNS is not ready yet (boot race with dnsmasq/DHCP). Adds `Restart=on-failure` with 5s delay — no hard dependency on dnsmasq.

Observed failure: `panic: lookup registry-1.docker.io: no such host` on first boot, works fine after manual restart.